### PR TITLE
修复 v2.0.6 打包版启动失败与 three 类型缺失问题

### DIFF
--- a/backend/src/achievements/store.js
+++ b/backend/src/achievements/store.js
@@ -4,7 +4,25 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const config = require('../config');
-const manifest = require('../../../shared/achievementManifest.json');
+
+function loadManifest() {
+  const candidates = [
+    process.env.T8PC_RES ? path.join(process.env.T8PC_RES, 'shared', 'achievementManifest.json') : '',
+    path.resolve(__dirname, '..', '..', '..', 'shared', 'achievementManifest.json'),
+  ];
+  for (const filePath of candidates) {
+    try {
+      if (filePath && fs.existsSync(filePath)) {
+        return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      }
+    } catch {
+      // Try the next known layout.
+    }
+  }
+  return require('../../../shared/achievementManifest.json');
+}
+
+const manifest = loadManifest();
 
 const SCHEMA = 't8-achievements';
 const VERSION = 1;

--- a/electron/loader.cjs
+++ b/electron/loader.cjs
@@ -131,6 +131,8 @@ function registerLoader() {
         // 因此需要在获不到外部依赖时回退到 loader.cjs(在 asar 内)的 require。
         // 这使得加密后端能访问主包 node_modules 里的 express/cors/multer/sharp 等。
         if (e && e.code === 'MODULE_NOT_FOUND') {
+          const text = String(id || '');
+          if (text.startsWith('.') || path.isAbsolute(text)) throw e;
           return require(id);
         }
         throw e;

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
+        "@types/three": "^0.184.1",
         "@vitejs/plugin-react": "^4.3.0",
         "autoprefixer": "^10.4.0",
         "concurrently": "^9.0.0",
@@ -356,6 +357,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmmirror.com/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
@@ -2559,6 +2567,13 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmmirror.com/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2769,6 +2784,28 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmmirror.com/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.1",
+      "resolved": "https://registry.npmmirror.com/@types/three/-/three-0.184.1.tgz",
+      "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
     "node_modules/@types/verror": {
       "version": "1.10.11",
       "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
@@ -2776,6 +2813,13 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmmirror.com/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -5567,6 +5611,13 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmmirror.com/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/filelist": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
@@ -6939,6 +6990,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/methods": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@types/three": "^0.184.1",
     "@vitejs/plugin-react": "^4.3.0",
     "autoprefixer": "^10.4.0",
     "concurrently": "^9.0.0",


### PR DESCRIPTION
## 背景

更新到最新 `main`（v2.0.6 / a7f700c）后，在 Windows 打包版验证时发现两个会阻断本地验证/启动的问题：

1. `npm run type-check` 因 `three` 缺少类型声明失败。
2. `npm run dist:dir` 能完成，但打包后的 exe 启动后后端没有监听 `127.0.0.1:18766`，窗口停留在启动中。

## 根因

### 1. 缺少 `@types/three`

`src/components/nodes/Panorama3DNode.tsx` 引入了 `three`，但 `devDependencies` 没有对应的 `@types/three`，导致 TypeScript 报：

```text
Could not find a declaration file for module 'three'
```

### 2. `.t8c` loader 对相对 require 的 fallback 过宽

打包后直接加载加密后端可复现：

```text
Error: Cannot find module './routes/achievements.t8c'
Require stack:
- resources/app.asar/electron/loader.cjs
- resources/backend-enc/server.t8c
```

`electron/loader.cjs` 在 `fileModule.require(id)` 抛 `MODULE_NOT_FOUND` 后，会 fallback 到 loader 自己的 `require(id)`。这个 fallback 对 bare package（如 `express`、`sharp`）是需要的，但不应作用于 `./routes/...` 这种相对路径，否则会从 `electron/loader.cjs` 所在目录错误解析。

本 PR 仅在 `id` 不是相对路径且不是绝对路径时 fallback 到 loader require。

### 3. 成就 manifest 路径在加密后端中不成立

修复 loader 后继续启动，会遇到：

```text
Error: Cannot find module '../../../shared/achievementManifest.json'
Require stack:
- resources/backend-enc/achievements/store.t8c
```

源码中 `backend/src/achievements/store.js` 的相对路径在源码树中成立，但加密后模块位于 `resources/backend-enc/achievements/store.t8c`，相对层级变化导致无法找到 `resources/shared/achievementManifest.json`。

本 PR 改为优先从 `process.env.T8PC_RES/shared/achievementManifest.json` 读取，并保留源码树 fallback。

## 修改内容

- 添加 `@types/three` 到 `devDependencies`。
- 限制 `.t8c` loader 的 fallback 范围，避免相对路径被错误改由 loader 目录解析。
- 调整成就 manifest 加载逻辑，使打包模式从 resources 根目录读取。

## 验证

已在 Windows 本地执行：

```bash
npm run type-check
node --test tests\jimengCliProvider.test.ts tests\mediaResolver.test.ts
npm run dist:dir
```

结果：

- `npm run type-check` 通过。
- 关键测试 16 个通过。
- `npm run dist:dir` 通过。
- 打包后启动 `dist_electron\win-unpacked\T8-PenguinCanvas.exe`，后端监听 `127.0.0.1:18766`，访问 `/` 返回 `HTTP 200 OK`。