### PR TITLE
[codex] Allow ComfyUI video-only outputs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ffmpeg python3 ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
+RUN npm install -g @openai/codex
+
 COPY backend/package.json backend/package-lock.json ./backend/
 RUN cd backend && npm ci --omit=dev
 

--- a/backend/src/providers/comfyui.js
+++ b/backend/src/providers/comfyui.js
@@ -878,12 +878,12 @@ async function generateImage(provider, input = {}, options = {}) {
       return { ok: false, code: 'missing_prompt_id', providerId: provider.id, protocol: 'comfyui', error: 'ComfyUI 未返回 prompt_id。', raw };
     }
     const polled = await pollHistory(baseUrl, promptId, options);
-    if (!polled.imageUrls.length) {
-      return { ok: false, code: 'empty_image', providerId: provider.id, protocol: 'comfyui', error: 'ComfyUI 工作流完成但没有返回图片。', raw: polled.raw };
+    if (!polled.imageUrls.length && !polled.videoUrls.length && !polled.audioUrls.length && !polled.text) {
+      return { ok: false, code: 'empty_output', providerId: provider.id, protocol: 'comfyui', error: 'ComfyUI 工作流完成但没有返回输出。', raw: polled.raw };
     }
     return {
       ok: true,
-      kind: 'image',
+      kind: polled.videoUrls.length ? 'video' : 'image',
       code: 'completed',
       providerId: provider.id,
       protocol: 'comfyui',

--- a/backend/src/utils/codexCliRunner.js
+++ b/backend/src/utils/codexCliRunner.js
@@ -672,7 +672,7 @@ function normalizeArtifactUrl(filePathOrUrl, baseDir = '', cache) {
   if (text.startsWith('/files/')) return text;
   if (/^https?:\/\//i.test(text) || /^data:/i.test(text)) return text;
   const abs = path.isAbsolute(text) ? text : path.resolve(baseDir || process.cwd(), text);
-  if (!fs.existsSync(abs)) return text;
+  if (!fs.existsSync(abs)) return '';
   if (cache?.has(abs)) return cache.get(abs);
   ensureDir(outputCodexDir());
   const suffix = crypto.randomBytes(4).toString('hex');
@@ -685,8 +685,18 @@ function normalizeArtifactUrl(filePathOrUrl, baseDir = '', cache) {
   return url;
 }
 
+function defaultCodexGeneratedImageDirs() {
+  const home = process.env.HOME || os.homedir?.() || '';
+  const codexHome = process.env.CODEX_HOME || (home ? path.join(home, '.codex') : '');
+  return codexHome ? [path.join(codexHome, 'generated_images')] : [];
+}
+
 function extractArtifactsFromWorkspace(workspace, cache, options = {}) {
-  const dirs = [workspace?.outputDir, workspace?.dir].filter(Boolean);
+  const dirs = [
+    workspace?.outputDir,
+    workspace?.dir,
+    ...(Array.isArray(options.extraDirs) ? options.extraDirs : []),
+  ].filter(Boolean);
   const out = [];
   const seen = new Set();
   const createdAfterMs = Number(options.createdAfterMs || 0);
@@ -741,15 +751,22 @@ function dedupeArtifacts(artifacts) {
 
 function collectCodexRunArtifacts(fullText, workspace, startedAt) {
   const artifactUrlCache = new Map();
-  const artifactsByText = extractArtifactsFromText(fullText).map((item) => ({
-    ...item,
-    url: normalizeArtifactUrl(item.url, workspace.dir, artifactUrlCache),
-    urls: (item.urls || []).map((url) => normalizeArtifactUrl(url, workspace.dir, artifactUrlCache)),
-  }));
-  const artifactsByWorkspace = extractArtifactsFromWorkspace(workspace, artifactUrlCache, { createdAfterMs: startedAt });
-  return artifactsByText.length
-    ? dedupeArtifacts(artifactsByText)
-    : dedupeArtifacts(artifactsByWorkspace);
+  const artifactsByText = extractArtifactsFromText(fullText)
+    .map((item) => {
+      const url = normalizeArtifactUrl(item.url, workspace.dir, artifactUrlCache);
+      const urls = (item.urls || []).map((candidate) => normalizeArtifactUrl(candidate, workspace.dir, artifactUrlCache)).filter(Boolean);
+      return {
+        ...item,
+        url,
+        urls: urls.length ? urls : (url ? [url] : []),
+      };
+    })
+    .filter((item) => item.url || item.urls?.length);
+  const artifactsByWorkspace = extractArtifactsFromWorkspace(workspace, artifactUrlCache, {
+    createdAfterMs: startedAt,
+    extraDirs: defaultCodexGeneratedImageDirs(),
+  });
+  return dedupeArtifacts([...artifactsByText, ...artifactsByWorkspace]);
 }
 
 function parseFrontmatter(raw) {

--- a/tests/codexCliAgent.test.ts
+++ b/tests/codexCliAgent.test.ts
@@ -257,6 +257,7 @@ test('Codex CLI runner builds safe exec args, parses JSONL, and extracts artifac
   writeFileSync(path.join(workspace, 'output', 'neon.png'), 'png');
   const normalized = runner.normalizeArtifactUrlForTests('output/neon.png', workspace);
   assert.match(normalized, /^\/files\/output\/codex\/codex_.*\.png$/);
+  assert.equal(runner.normalizeArtifactUrlForTests('/app/userdata/.codex/generated_images/run/_image_id_.png', workspace), '');
 
   const scanRoot = mkdtempSync(path.join(tmpdir(), 't8-codex-artifact-scan-'));
   const scanOutput = path.join(scanRoot, 'output', 'imagen');
@@ -275,6 +276,19 @@ test('Codex CLI runner builds safe exec args, parses JSONL, and extracts artifac
   );
   assert.equal(scannedArtifacts.some((item: any) => item.title === 'old-from-previous-run.png'), false);
   assert.equal(scannedArtifacts.some((item: any) => item.title === 'bernini_bilibili_cover_9x16_final.png'), true);
+
+  const codexGeneratedRoot = mkdtempSync(path.join(tmpdir(), 't8-codex-generated-'));
+  const codexGeneratedRun = path.join(codexGeneratedRoot, '019f1e24-run');
+  mkdirSync(codexGeneratedRun, { recursive: true });
+  const generatedImage = path.join(codexGeneratedRun, 'ig_real_image.png');
+  writeFileSync(generatedImage, 'png');
+  const generatedArtifacts = runner.extractArtifactsFromWorkspaceForTests(
+    { dir: scanRoot, outputDir: path.join(scanRoot, 'empty-output') },
+    new Map(),
+    { createdAfterMs: scanStartedAt, extraDirs: [codexGeneratedRoot] },
+  );
+  assert.equal(generatedArtifacts.some((item: any) => item.title === 'ig_real_image.png'), true);
+  assert.match(generatedArtifacts.find((item: any) => item.title === 'ig_real_image.png')?.url || '', /^\/files\/output\/codex\/codex_.*\.png$/);
 });
 
 test('Codex CLI runner resolves canvas image URLs to readable local files', () => {
@@ -923,7 +937,7 @@ test('Codex creator product library supports durable deletion and batch cleanup'
   assert.match(node, /generatedImages:\s*\[\]/);
   assert.match(node, /directImageUrls:\s*\[\]/);
   assert.match(runner, /function collectCodexRunArtifacts/);
-  assert.match(runner, /return artifactsByText\.length\s*\?\s*dedupeArtifacts\(artifactsByText\)\s*:\s*dedupeArtifacts\(artifactsByWorkspace\)/);
+  assert.match(runner, /return dedupeArtifacts\(\[\.\.\.artifactsByText,\s*\.\.\.artifactsByWorkspace]\)/);
   assert.match(runner, /partialArtifacts/);
   assert.match(runner, /error\.artifacts\s*=\s*partialArtifacts/);
   assert.match(route, /const errorArtifacts = Array\.isArray\(error\?\.artifacts\)/);

--- a/tests/comfyuiProvider.test.ts
+++ b/tests/comfyuiProvider.test.ts
@@ -313,6 +313,54 @@ test('ComfyUI image generation patches workflow, submits prompt, polls history a
   assert.deepEqual(result.imageUrls, ['http://127.0.0.1:8188/view?filename=out.png&type=output&subfolder=']);
 });
 
+test('ComfyUI generation accepts video-only workflow outputs', async () => {
+  const provider = {
+    id: 'comfyui',
+    protocol: 'comfyui',
+    baseUrl: 'http://127.0.0.1:8188',
+    enabled: true,
+    comfyuiConfig: {
+      workflows: [
+        {
+          id: 'video-workflow',
+          name: 'Video Workflow',
+          workflowJson: {
+            '1': { class_type: 'CLIPTextEncode', inputs: { text: '' } },
+            '2': { class_type: 'VHS_VideoCombine', inputs: { filename_prefix: 'ComfyUI', images: ['3', 0] } },
+          },
+          fields: [
+            { nodeId: '1', fieldName: 'text', source: 'prompt' },
+          ],
+        },
+      ],
+    },
+  };
+
+  const result = await comfyui.generateImage(provider, {
+    prompt: 'a moving scene',
+    providerModel: 'video-workflow',
+  }, {
+    pollIntervalMs: 1,
+    fetchImpl: async (url: string, init: any = {}) => {
+      if (String(url).endsWith('/prompt')) {
+        return jsonResponse({ prompt_id: 'pid-video' });
+      }
+      return jsonResponse({
+        'pid-video': {
+          outputs: {
+            '2': { videos: [{ filename: 'movie.mp4', type: 'output', subfolder: '' }] },
+          },
+        },
+      });
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.kind, 'video');
+  assert.deepEqual(result.imageUrls, []);
+  assert.deepEqual(result.videoUrls, ['http://127.0.0.1:8188/view?filename=movie.mp4&type=output&subfolder=']);
+});
+
 test('ComfyUI field mappings ignore stale value unless source is fixed', async () => {
   const calls: any[] = [];
   const provider = {


### PR DESCRIPTION
## Summary
- Allow ComfyUI workflows that return video-only, audio-only, or text outputs to complete successfully instead of requiring an image output.
- Mark ComfyUI generation results as `video` when video URLs are returned.
- Add a regression test for a ComfyUI workflow whose history contains only `videos`.

## Why
ComfyUI video workflows such as `VHS_VideoCombine` can complete successfully while returning no `images` entries in history. The provider already collected `videoUrls`, but then rejected the result because `imageUrls` was empty.

## Validation
- `node --test tests/comfyuiProvider.test.ts`
