### PR TITLE
[codex] Add web asset reference import

### DIFF
--- a/backend/src/routes/vibexBridge.js
+++ b/backend/src/routes/vibexBridge.js
@@ -64,7 +64,7 @@ function normalizeMessage(input) {
     const prompt = cleanText(payload.prompt || payload.text || payload.outputText);
     if (images.length === 0 && !prompt) return null;
 
-    const mode = ['prompt', 'image', 'both'].includes(String(payload.mode || '').trim())
+    const mode = ['prompt', 'image', 'both', 'reference'].includes(String(payload.mode || '').trim())
       ? String(payload.mode || '').trim()
       : 'both';
     const messageId = cleanText(payload.messageId || raw.messageId || `web-image-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`, 180);
@@ -81,7 +81,7 @@ function normalizeMessage(input) {
         sourceImageUrl: cleanUrl(payload.sourceImageUrl),
         pageUrl: cleanText(payload.pageUrl || raw.pageUrl, 2048),
         pageTitle: cleanText(payload.pageTitle || raw.pageTitle, 200),
-        source: 'web-image-reverse',
+        source: cleanText(payload.source, 120) || 'web-image-reverse',
         createdAt: Number(payload.createdAt) || Date.now(),
         metadata: {
           ...cleanMetadata(payload.metadata),

--- a/backend/src/routes/webAssets.js
+++ b/backend/src/routes/webAssets.js
@@ -1,0 +1,221 @@
+'use strict';
+
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const dns = require('dns').promises;
+const net = require('net');
+const config = require('../config');
+
+const router = express.Router();
+
+const MAX_ITEMS = 80;
+const MAX_ITEM_BYTES = 80 * 1024 * 1024;
+const REMOTE_FETCH_TIMEOUT_MS = 30_000;
+const IMAGE_MIME_EXT = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+  'image/avif': 'avif',
+  'image/bmp': 'bmp',
+};
+
+function cleanText(value, maxLen = 240) {
+  return String(value || '').replace(/\s+/g, ' ').trim().slice(0, maxLen);
+}
+
+function safeFilenameStem(value, fallback = 'web-image') {
+  const clean = cleanText(value, 120)
+    .replace(/\.[a-z0-9]{2,5}$/i, '')
+    .replace(/[\\/:*?"<>|]+/g, '_')
+    .replace(/\s+/g, '_')
+    .replace(/[._-]+$/g, '')
+    .replace(/^[._-]+/g, '')
+    .slice(0, 80);
+  return clean || fallback;
+}
+
+function mimeToExt(mime) {
+  const clean = String(mime || '').split(';', 1)[0].trim().toLowerCase();
+  return IMAGE_MIME_EXT[clean] || '';
+}
+
+function sniffImageExt(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 12) return '';
+  if (buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) return 'png';
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) return 'jpg';
+  if (buffer.subarray(0, 4).toString('ascii') === 'GIF8') return 'gif';
+  if (buffer.subarray(0, 4).toString('ascii') === 'RIFF' && buffer.subarray(8, 12).toString('ascii') === 'WEBP') return 'webp';
+  if (buffer.subarray(4, 12).toString('ascii') === 'ftypavif') return 'avif';
+  if (buffer[0] === 0x42 && buffer[1] === 0x4d) return 'bmp';
+  return '';
+}
+
+function imageMimeFromExt(ext) {
+  const clean = String(ext || '').toLowerCase();
+  if (clean === 'jpg' || clean === 'jpeg') return 'image/jpeg';
+  if (clean === 'png') return 'image/png';
+  if (clean === 'webp') return 'image/webp';
+  if (clean === 'gif') return 'image/gif';
+  if (clean === 'avif') return 'image/avif';
+  if (clean === 'bmp') return 'image/bmp';
+  return 'application/octet-stream';
+}
+
+function parseDataUrl(dataUrl) {
+  const match = /^data:(image\/(?:png|jpe?g|webp|gif|avif|bmp));base64,([\s\S]+)$/i.exec(String(dataUrl || '').trim());
+  if (!match) throw new Error('dataUrl 只支持常见图片格式');
+  const buffer = Buffer.from(match[2], 'base64');
+  if (!buffer.length) throw new Error('图片数据为空');
+  if (buffer.length > MAX_ITEM_BYTES) throw new Error('图片超过网页采集导入上限');
+  const ext = sniffImageExt(buffer) || mimeToExt(match[1]);
+  if (!ext) throw new Error('无法识别图片格式');
+  return { buffer, mime: imageMimeFromExt(ext), ext };
+}
+
+function isPrivateIp(ip) {
+  if (!ip) return true;
+  if (net.isIPv4(ip)) {
+    const parts = ip.split('.').map((part) => Number(part));
+    return (
+      parts[0] === 10 ||
+      parts[0] === 127 ||
+      (parts[0] === 169 && parts[1] === 254) ||
+      (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+      (parts[0] === 192 && parts[1] === 168) ||
+      parts[0] === 0
+    );
+  }
+  const clean = ip.toLowerCase();
+  return clean === '::1' || clean.startsWith('fc') || clean.startsWith('fd') || clean.startsWith('fe80:');
+}
+
+async function assertSafeRemoteUrl(rawUrl) {
+  let parsed;
+  try {
+    parsed = new URL(String(rawUrl || '').trim());
+  } catch {
+    throw new Error('远程图片 URL 不合法');
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('远程图片仅支持 http(s)');
+  }
+  const hostname = parsed.hostname.toLowerCase();
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
+    throw new Error('不允许从本机地址采集远程图片');
+  }
+  if (net.isIP(hostname) && isPrivateIp(hostname)) {
+    throw new Error('不允许从内网地址采集远程图片');
+  }
+  const records = await dns.lookup(hostname, { all: true, verbatim: false });
+  if (!records.length || records.some((record) => isPrivateIp(record.address))) {
+    throw new Error('远程图片地址解析到不安全的网络位置');
+  }
+  return parsed;
+}
+
+async function fetchRemoteImage(rawUrl) {
+  let parsed = await assertSafeRemoteUrl(rawUrl);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REMOTE_FETCH_TIMEOUT_MS);
+  try {
+    let response = null;
+    for (let redirectCount = 0; redirectCount < 5; redirectCount += 1) {
+      response = await fetch(parsed.href, {
+        redirect: 'manual',
+        signal: controller.signal,
+        headers: { 'User-Agent': 'T8-PenguinCanvas-WebAssetImporter/1.0' },
+      });
+      if (![301, 302, 303, 307, 308].includes(response.status)) break;
+      const location = response.headers.get('location');
+      if (!location) throw new Error('远程图片重定向缺少 Location');
+      parsed = await assertSafeRemoteUrl(new URL(location, parsed.href).href);
+    }
+    if (!response) throw new Error('远程图片下载失败');
+    if ([301, 302, 303, 307, 308].includes(response.status)) {
+      throw new Error('远程图片重定向次数过多');
+    }
+    if (!response.ok) throw new Error(`远程图片下载失败: HTTP ${response.status}`);
+    const declaredSize = Number(response.headers.get('content-length') || 0);
+    if (declaredSize > MAX_ITEM_BYTES) throw new Error('图片超过网页采集导入上限');
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (!buffer.length) throw new Error('远程图片为空');
+    if (buffer.length > MAX_ITEM_BYTES) throw new Error('图片超过网页采集导入上限');
+    const ext = sniffImageExt(buffer) || mimeToExt(response.headers.get('content-type')) || path.extname(parsed.pathname).replace(/^\./, '').toLowerCase();
+    if (!IMAGE_MIME_EXT[imageMimeFromExt(ext)]) throw new Error('远程资源不是支持的图片格式');
+    return { buffer, mime: imageMimeFromExt(ext), ext };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function sourceName(entry, index) {
+  const explicit = safeFilenameStem(entry?.name || entry?.filename || '', '');
+  if (explicit) return explicit;
+  try {
+    const url = new URL(String(entry?.url || ''));
+    return safeFilenameStem(decodeURIComponent(path.basename(url.pathname || '')), `web-image-${index + 1}`);
+  } catch {
+    return `web-image-${index + 1}`;
+  }
+}
+
+function saveImportedImage(entry, index, image) {
+  if (!fs.existsSync(config.INPUT_DIR)) fs.mkdirSync(config.INPUT_DIR, { recursive: true });
+  const stem = sourceName(entry, index);
+  const filename = `web_${Date.now()}_${index}_${Math.random().toString(36).slice(2, 7)}_${stem}.${image.ext}`;
+  const target = path.join(config.INPUT_DIR, filename);
+  fs.writeFileSync(target, image.buffer);
+  return {
+    ok: true,
+    filename,
+    url: `/files/input/${filename}`,
+    kind: 'image',
+    name: `${stem}.${image.ext}`,
+    size: image.buffer.length,
+    mime: image.mime,
+    sourceUrl: cleanText(entry?.url, 2048),
+    pageUrl: cleanText(entry?.pageUrl, 2048),
+    pageTitle: cleanText(entry?.pageTitle, 200),
+  };
+}
+
+router.post('/import', express.json({ limit: '120mb' }), async (req, res) => {
+  try {
+    const rawItems = Array.isArray(req.body?.items) ? req.body.items : [];
+    if (rawItems.length === 0) {
+      return res.status(400).json({ success: false, error: '缺少网页素材 items' });
+    }
+    const items = [];
+    for (const [index, entry] of rawItems.slice(0, MAX_ITEMS).entries()) {
+      try {
+        const dataUrl = String(entry?.dataUrl || entry?.data || '').trim().slice(0, 140_000_000);
+        const url = cleanText(entry?.url, 4096);
+        if (!dataUrl && !url) throw new Error('缺少图片 URL 或 dataUrl');
+        const image = dataUrl ? parseDataUrl(dataUrl) : await fetchRemoteImage(url);
+        items.push(saveImportedImage(entry, index, image));
+      } catch (error) {
+        items.push({
+          ok: false,
+          url: cleanText(entry?.url, 2048),
+          name: cleanText(entry?.name || entry?.filename, 200),
+          error: error?.message || '导入失败',
+        });
+      }
+    }
+    res.json({
+      success: true,
+      data: {
+        count: items.filter((item) => item.ok).length,
+        failed: items.filter((item) => !item.ok).length,
+        items,
+      },
+    });
+  } catch (error) {
+    res.status(500).json({ success: false, error: error?.message || String(error) });
+  }
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -76,6 +76,7 @@ const vibexBridgeRouter = require('./routes/vibexBridge');
 const videoOpsRouter = require('./routes/videoOps');
 const batchTagsRouter = require('./routes/batchTags');
 const photoshopBridgeRouter = require('./routes/photoshopBridge');
+const webAssetsRouter = require('./routes/webAssets');
 const { registerLocalExtensions } = require('./extensions/localExtensions');
 const localHooks = require('./extensions/runtimeHooks');
 
@@ -101,6 +102,7 @@ app.use('/api/vibex-bridge', vibexBridgeRouter);
 app.use('/api/video-ops', videoOpsRouter);
 app.use('/api/batch-tags', batchTagsRouter);
 app.use('/api/photoshop-bridge', photoshopBridgeRouter);
+app.use('/api/web-assets', webAssetsRouter);
 registerLocalExtensions(app, { config, express, logger: console, hooks: localHooks });
 
 // ========== 前端静态资源(仅打包模式) ==========

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,14 +1,22 @@
 {
   "manifest_version": 3,
   "name": "T8 Penguin Canvas Web Image Reverse",
-  "description": "网页图片右键反推提示词、生成图片，并发送回 T8 画布。",
-  "version": "1.1.0",
+  "description": "网页图片右键反推、批量采集网页图片，并发送回 T8 画布。",
+  "version": "1.2.0",
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "采集网页图片到 T8"
+  },
+  "side_panel": {
+    "default_path": "sidepanel.html"
+  },
   "permissions": [
     "activeTab",
     "contextMenus",
     "scripting",
     "storage",
-    "tabs"
+    "tabs",
+    "sidePanel"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>T8 网页采集</title>
+  <link rel="stylesheet" href="styles/importer.css">
+</head>
+<body>
+  <main class="t8-importer">
+    <header class="top">
+      <div>
+        <h1>T8 网页采集</h1>
+        <p>扫描当前网页图片，导入画布当参考图</p>
+      </div>
+      <button id="pinBtn" class="icon-btn" type="button" title="固定到侧边栏">固定</button>
+    </header>
+
+    <section class="settings">
+      <label>
+        <span>后端地址</span>
+        <input id="backendInput" type="text" value="http://127.0.0.1:18766">
+      </label>
+      <div class="checks">
+        <label><input id="autoScrollInput" type="checkbox"> 自动滚动</label>
+        <label><input id="filterSmallInput" type="checkbox" checked> 过滤小图</label>
+      </div>
+    </section>
+
+    <section class="actions">
+      <button id="scanBtn" class="primary" type="button">扫描页面</button>
+      <button id="captureBtn" type="button">截取当前画面</button>
+    </section>
+
+    <section class="summary">
+      <span id="countText">未扫描</span>
+      <span>
+        <button id="selectAllBtn" type="button">全选</button>
+        <button id="clearBtn" type="button">清空</button>
+      </span>
+    </section>
+
+    <section id="grid" class="grid empty">
+      <div class="empty-text">点击“扫描页面”开始采集图片。</div>
+    </section>
+
+    <footer>
+      <span id="statusText">请先启动 T8 后端。</span>
+      <button id="importBtn" class="primary" type="button" disabled>导入画布</button>
+    </footer>
+  </main>
+  <script src="scripts/importer.js"></script>
+</body>
+</html>

--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -283,6 +283,47 @@ async function generateImage(message) {
   };
 }
 
+async function importWebAssets(message) {
+  const settings = await storageGet({ t8_backend_base: DEFAULT_BACKEND_BASE });
+  let lastError = null;
+  for (const backendBase of backendCandidates(message?.backendBase || settings.t8_backend_base)) {
+    try {
+      const response = await fetch(absoluteBackendUrl(backendBase, '/api/web-assets/import'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items: message?.items || [] }),
+      });
+      const data = await readJsonResponse(response);
+      if (!response.ok || data?.success === false) {
+        lastError = new Error(data?.error || `T8 后端返回 HTTP ${response.status}`);
+        continue;
+      }
+      const imported = (data?.data?.items || []).filter((item) => item?.ok && item?.url);
+      if (message?.sendToCanvas !== false && imported.length) {
+        await sendToCanvas({
+          mode: 'reference',
+          source: 'web-asset-importer',
+          images: imported.map((item) => ({
+            url: item.url,
+            name: item.name || item.filename || '',
+            size: item.size || 0,
+            mime: item.mime || '',
+          })),
+          imageUrls: imported.map((item) => item.url),
+          pageUrl: message?.pageUrl || '',
+          pageTitle: message?.pageTitle || '',
+          sourceImageUrl: imported[0]?.sourceUrl || imported[0]?.url || '',
+          createdAt: Date.now(),
+        });
+      }
+      return { ok: true, backendBase, data };
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError || new Error('无法连接 T8 网页素材导入接口。');
+}
+
 chrome.runtime.onInstalled.addListener(installContextMenu);
 chrome.runtime.onStartup.addListener(installContextMenu);
 installContextMenu();
@@ -329,6 +370,13 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     generateImage(message)
       .then((result) => sendResponse(result))
       .catch((error) => sendResponse({ ok: false, error: normalizeBackendFetchError(error), data: { success: false } }));
+    return true;
+  }
+
+  if (message?.action === 't8WebImage.importWebAssets') {
+    importWebAssets(message)
+      .then((result) => sendResponse(result))
+      .catch((error) => sendResponse({ ok: false, error: normalizeBackendFetchError(error) }));
     return true;
   }
 

--- a/extension/scripts/importer.js
+++ b/extension/scripts/importer.js
@@ -1,0 +1,360 @@
+const els = {
+  backend: document.getElementById('backendInput'),
+  autoScroll: document.getElementById('autoScrollInput'),
+  filterSmall: document.getElementById('filterSmallInput'),
+  pin: document.getElementById('pinBtn'),
+  scan: document.getElementById('scanBtn'),
+  capture: document.getElementById('captureBtn'),
+  count: document.getElementById('countText'),
+  grid: document.getElementById('grid'),
+  status: document.getElementById('statusText'),
+  selectAll: document.getElementById('selectAllBtn'),
+  clear: document.getElementById('clearBtn'),
+  import: document.getElementById('importBtn'),
+};
+
+const DEFAULT_BACKEND_BASE = 'http://127.0.0.1:18766';
+let items = [];
+let selected = new Set();
+
+function setStatus(text) {
+  els.status.textContent = text || '';
+}
+
+function backendBase() {
+  let value = String(els.backend.value || '').trim() || DEFAULT_BACKEND_BASE;
+  if (!/^https?:\/\//i.test(value)) value = `http://${value}`;
+  try {
+    const url = new URL(value);
+    return `${url.protocol}//${url.host}`;
+  } catch {
+    return DEFAULT_BACKEND_BASE;
+  }
+}
+
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, (ch) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch]));
+}
+
+function imageName(url) {
+  if (/^data:/i.test(String(url || ''))) return 'web-capture.png';
+  try {
+    const parsed = new URL(url);
+    return decodeURIComponent(parsed.pathname.split('/').filter(Boolean).pop() || parsed.hostname || 'web-image');
+  } catch {
+    return 'web-image';
+  }
+}
+
+function itemKey(item) {
+  return item.id || item.url;
+}
+
+function visibleItems() {
+  if (!els.filterSmall.checked) return items;
+  return items.filter((item) => {
+    const w = Number(item.width || 0);
+    const h = Number(item.height || 0);
+    return !w || !h || (w >= 360 && h >= 240);
+  });
+}
+
+function updateSelection() {
+  const visible = visibleItems();
+  const visibleKeys = new Set(visible.map(itemKey));
+  selected = new Set([...selected].filter((key) => visibleKeys.has(key)));
+  const hidden = items.length - visible.length;
+  els.count.textContent = items.length
+    ? `${visible.length} 张${hidden ? `（过滤 ${hidden}）` : ''} / 已选 ${selected.size}`
+    : '未扫描';
+  els.import.disabled = selected.size === 0;
+}
+
+function renderGrid() {
+  const visible = visibleItems();
+  updateSelection();
+  if (!visible.length) {
+    els.grid.className = 'grid empty';
+    els.grid.innerHTML = `<div class="empty-text">${items.length ? '当前过滤条件下没有可用图片。' : '没有扫描到图片。'}</div>`;
+    return;
+  }
+  els.grid.className = 'grid';
+  els.grid.innerHTML = visible.map((item, index) => {
+    const key = itemKey(item);
+    const checked = selected.has(key);
+    const title = `${item.width || '?'} x ${item.height || '?'} · ${item.url}`;
+    return `<article class="card ${checked ? 'selected' : ''}" data-index="${index}" title="${escapeHtml(title)}">
+      <div class="thumb"><img src="${escapeHtml(item.url)}" alt="" loading="lazy" referrerpolicy="no-referrer"></div>
+      <label class="meta">
+        <input type="checkbox" ${checked ? 'checked' : ''}>
+        <span>${escapeHtml(item.name || imageName(item.url))}</span>
+      </label>
+    </article>`;
+  }).join('');
+  els.grid.querySelectorAll('.card').forEach((card) => {
+    const item = visible[Number(card.dataset.index)];
+    card.addEventListener('click', (event) => {
+      event.preventDefault();
+      if (!item) return;
+      const key = itemKey(item);
+      if (selected.has(key)) selected.delete(key);
+      else selected.add(key);
+      renderGrid();
+    });
+  });
+}
+
+async function activeTab() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.id) throw new Error('没有可扫描的当前标签页');
+  return tab;
+}
+
+function autoScrollPage() {
+  return new Promise((resolve) => {
+    let steps = 0;
+    const maxSteps = 8;
+    const originalX = window.scrollX;
+    const originalY = window.scrollY;
+    const tick = () => {
+      window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'auto' });
+      steps += 1;
+      if (steps >= maxSteps) {
+        window.scrollTo(originalX, originalY);
+        resolve(true);
+        return;
+      }
+      setTimeout(tick, 260);
+    };
+    tick();
+  });
+}
+
+function collectPageImages() {
+  const out = [];
+  const seen = new Set();
+  const push = (url, meta = {}) => {
+    const clean = String(url || '').trim();
+    if (!clean || seen.has(clean)) return;
+    if (!/^(https?:\/\/|blob:|data:image\/)/i.test(clean)) return;
+    seen.add(clean);
+    out.push({
+      url: clean,
+      width: Number(meta.width || 0) || 0,
+      height: Number(meta.height || 0) || 0,
+      name: meta.name || '',
+    });
+  };
+
+  document.querySelectorAll('img').forEach((img) => {
+    push(img.currentSrc || img.src, {
+      width: img.naturalWidth || img.width,
+      height: img.naturalHeight || img.height,
+      name: img.alt || img.title || '',
+    });
+    const srcset = img.getAttribute('srcset') || '';
+    srcset.split(',').forEach((part) => push(part.trim().split(/\s+/)[0]));
+  });
+
+  document.querySelectorAll('source[srcset]').forEach((source) => {
+    String(source.getAttribute('srcset') || '').split(',').forEach((part) => push(part.trim().split(/\s+/)[0]));
+  });
+
+  document.querySelectorAll('canvas').forEach((canvas, index) => {
+    try {
+      if (canvas.width < 80 || canvas.height < 80) return;
+      push(canvas.toDataURL('image/png'), { width: canvas.width, height: canvas.height, name: `canvas-${index + 1}.png` });
+    } catch {}
+  });
+
+  document.querySelectorAll('*').forEach((el) => {
+    const bg = getComputedStyle(el).backgroundImage || '';
+    const matches = bg.matchAll(/url\((['"]?)(.*?)\1\)/g);
+    for (const match of matches) push(match[2]);
+  });
+
+  return out;
+}
+
+function mergeFrameResults(results) {
+  const seen = new Set();
+  const merged = [];
+  (results || []).forEach((frame) => {
+    (frame?.result || []).forEach((item) => {
+      if (!item?.url || seen.has(item.url)) return;
+      seen.add(item.url);
+      merged.push({ ...item, id: item.url, name: item.name || imageName(item.url) });
+    });
+  });
+  return merged.slice(0, 240);
+}
+
+async function scanPage() {
+  const tab = await activeTab();
+  setStatus('正在扫描当前页面...');
+  if (els.autoScroll.checked) {
+    setStatus('正在滚动触发懒加载...');
+    await chrome.scripting.executeScript({ target: { tabId: tab.id, allFrames: true }, func: autoScrollPage }).catch(() => {});
+  }
+  const results = await chrome.scripting.executeScript({
+    target: { tabId: tab.id, allFrames: true },
+    func: collectPageImages,
+  });
+  items = mergeFrameResults(results).map((item) => ({ ...item, pageUrl: tab.url || '', pageTitle: tab.title || '' }));
+  selected = new Set();
+  renderGrid();
+  setStatus(items.length ? `已扫描到 ${items.length} 张图片。` : '当前页面没有扫描到图片。');
+}
+
+async function captureVisible() {
+  const tab = await activeTab();
+  setStatus('正在截取当前可见画面...');
+  const dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId, { format: 'png' });
+  const size = await new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
+    img.onerror = () => resolve({ width: 0, height: 0 });
+    img.src = dataUrl;
+  });
+  const item = {
+    id: `capture-${Date.now()}`,
+    url: dataUrl,
+    dataUrl,
+    name: `capture-${Date.now()}.png`,
+    pageUrl: tab.url || '',
+    pageTitle: tab.title || '',
+    ...size,
+  };
+  items = [item, ...items];
+  selected.add(item.id);
+  renderGrid();
+  setStatus('已截取当前画面，可直接导入。');
+}
+
+function fetchUrlsAsDataUrls(urls) {
+  const readOne = (url) => new Promise((resolve) => {
+    const entry = { url, ok: false, dataUrl: '', contentType: '', error: '' };
+    if (/^data:image\//i.test(url)) {
+      entry.ok = true;
+      entry.dataUrl = url;
+      entry.contentType = url.match(/^data:([^;,]+)/i)?.[1] || '';
+      resolve(entry);
+      return;
+    }
+    fetch(url, { credentials: 'include' })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.blob();
+      })
+      .then((blob) => new Promise((res, rej) => {
+        entry.contentType = blob.type || '';
+        const reader = new FileReader();
+        reader.onload = () => res(String(reader.result || ''));
+        reader.onerror = () => rej(new Error('读取失败'));
+        reader.readAsDataURL(blob);
+      }))
+      .then((dataUrl) => {
+        entry.ok = true;
+        entry.dataUrl = dataUrl;
+        resolve(entry);
+      })
+      .catch((error) => {
+        entry.error = error?.message || '读取失败';
+        resolve(entry);
+      });
+  });
+  return Promise.all(urls.map(readOne));
+}
+
+async function enrichInlineData(picked) {
+  const needRead = picked.filter((item) => /^blob:|^data:image\//i.test(item.url) && !item.dataUrl);
+  const byUrl = new Map();
+  picked.forEach((item) => {
+    if (item.dataUrl) byUrl.set(item.url, { ok: true, dataUrl: item.dataUrl, contentType: 'image/png' });
+  });
+  if (!needRead.length) return byUrl;
+  const tab = await activeTab();
+  const results = await chrome.scripting.executeScript({
+    target: { tabId: tab.id, allFrames: true },
+    func: fetchUrlsAsDataUrls,
+    args: [needRead.map((item) => item.url)],
+  });
+  (results || []).forEach((frame) => {
+    (frame?.result || []).forEach((entry) => {
+      if (!entry?.url) return;
+      const current = byUrl.get(entry.url);
+      if (!current || (!current.ok && entry.ok)) byUrl.set(entry.url, entry);
+    });
+  });
+  return byUrl;
+}
+
+async function importSelected() {
+  const visible = visibleItems();
+  const picked = visible.filter((item) => selected.has(itemKey(item)));
+  if (!picked.length) return;
+  await chrome.storage.local.set({ t8_backend_base: backendBase() });
+  els.import.disabled = true;
+  setStatus(`正在导入 ${picked.length} 张图片...`);
+  const inline = await enrichInlineData(picked);
+  const payloadItems = picked.map((item) => {
+    const local = inline.get(item.url);
+    return {
+      url: local?.ok ? '' : item.url,
+      dataUrl: local?.ok ? local.dataUrl : '',
+      contentType: local?.contentType || '',
+      name: item.name || imageName(item.url),
+      width: item.width || 0,
+      height: item.height || 0,
+      pageUrl: item.pageUrl || '',
+      pageTitle: item.pageTitle || '',
+    };
+  });
+  const tab = await activeTab().catch(() => ({}));
+  const response = await new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage({
+      action: 't8WebImage.importWebAssets',
+      backendBase: backendBase(),
+      items: payloadItems,
+      sendToCanvas: true,
+      pageUrl: tab.url || picked[0]?.pageUrl || '',
+      pageTitle: tab.title || picked[0]?.pageTitle || '',
+    }, (result) => {
+      const runtimeError = chrome.runtime.lastError;
+      if (runtimeError) reject(new Error(runtimeError.message));
+      else resolve(result || {});
+    });
+  });
+  if (!response.ok) throw new Error(response.error || '导入失败');
+  const data = response.data?.data || response.data || {};
+  setStatus(`导入完成：成功 ${data.count || 0} 张${data.failed ? `，失败 ${data.failed} 张` : ''}。`);
+  els.import.disabled = selected.size === 0;
+}
+
+async function openSidePanel() {
+  const tab = await activeTab();
+  if (chrome.sidePanel?.open) await chrome.sidePanel.open({ windowId: tab.windowId });
+}
+
+els.scan.addEventListener('click', () => scanPage().catch((error) => setStatus(error?.message || '扫描失败')));
+els.capture.addEventListener('click', () => captureVisible().catch((error) => setStatus(error?.message || '截图失败')));
+els.import.addEventListener('click', () => importSelected().catch((error) => {
+  setStatus(error?.message || '导入失败');
+  els.import.disabled = selected.size === 0;
+}));
+els.selectAll.addEventListener('click', () => {
+  selected = new Set(visibleItems().map(itemKey));
+  renderGrid();
+});
+els.clear.addEventListener('click', () => {
+  selected.clear();
+  renderGrid();
+});
+els.filterSmall.addEventListener('change', renderGrid);
+els.backend.addEventListener('change', () => chrome.storage.local.set({ t8_backend_base: backendBase() }));
+els.pin.addEventListener('click', () => openSidePanel().catch((error) => setStatus(error?.message || '无法打开侧边栏')));
+
+(async function init() {
+  const stored = await chrome.storage.local.get({ t8_backend_base: DEFAULT_BACKEND_BASE });
+  els.backend.value = stored.t8_backend_base || DEFAULT_BACKEND_BASE;
+})();

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>T8 网页采集</title>
+  <link rel="stylesheet" href="styles/importer.css">
+</head>
+<body class="side-panel">
+  <main class="t8-importer">
+    <header class="top">
+      <div>
+        <h1>T8 网页采集</h1>
+        <p>侧边栏会跟随当前活动标签页扫描</p>
+      </div>
+      <button id="pinBtn" class="icon-btn" type="button" title="已在侧边栏">已固定</button>
+    </header>
+
+    <section class="settings">
+      <label>
+        <span>后端地址</span>
+        <input id="backendInput" type="text" value="http://127.0.0.1:18766">
+      </label>
+      <div class="checks">
+        <label><input id="autoScrollInput" type="checkbox"> 自动滚动</label>
+        <label><input id="filterSmallInput" type="checkbox" checked> 过滤小图</label>
+      </div>
+    </section>
+
+    <section class="actions">
+      <button id="scanBtn" class="primary" type="button">扫描页面</button>
+      <button id="captureBtn" type="button">截取当前画面</button>
+    </section>
+
+    <section class="summary">
+      <span id="countText">未扫描</span>
+      <span>
+        <button id="selectAllBtn" type="button">全选</button>
+        <button id="clearBtn" type="button">清空</button>
+      </span>
+    </section>
+
+    <section id="grid" class="grid empty">
+      <div class="empty-text">点击“扫描页面”开始采集图片。</div>
+    </section>
+
+    <footer>
+      <span id="statusText">请先启动 T8 后端。</span>
+      <button id="importBtn" class="primary" type="button" disabled>导入画布</button>
+    </footer>
+  </main>
+  <script src="scripts/importer.js"></script>
+</body>
+</html>

--- a/extension/styles/importer.css
+++ b/extension/styles/importer.css
@@ -1,0 +1,246 @@
+:root {
+  color-scheme: light dark;
+  font-family: Inter, "Microsoft YaHei", system-ui, sans-serif;
+  background: #f7fafc;
+  color: #142033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  width: 390px;
+  min-height: 560px;
+  margin: 0;
+  background: #f7fafc;
+}
+
+body.side-panel {
+  width: auto;
+  min-width: 320px;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.t8-importer {
+  display: flex;
+  min-height: 560px;
+  flex-direction: column;
+}
+
+.top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px;
+  border-bottom: 1px solid #d8e1ec;
+  background: #ffffff;
+}
+
+.top h1 {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+.top p {
+  margin: 4px 0 0;
+  color: #64748b;
+  font-size: 12px;
+}
+
+.settings {
+  display: grid;
+  gap: 10px;
+  padding: 12px 14px;
+  background: #eef6ff;
+  border-bottom: 1px solid #d8e1ec;
+}
+
+.settings label {
+  display: grid;
+  gap: 5px;
+  font-size: 12px;
+  color: #334155;
+}
+
+.settings input[type="text"] {
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 8px 9px;
+  color: #0f172a;
+  background: #fff;
+  outline: none;
+}
+
+.checks {
+  display: flex;
+  gap: 14px;
+}
+
+.checks label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.actions,
+.summary,
+footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+}
+
+.summary {
+  justify-content: space-between;
+  color: #475569;
+  font-size: 12px;
+}
+
+button {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 7px 10px;
+  background: #fff;
+  color: #1e293b;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: .55;
+}
+
+button.primary {
+  border-color: #0891b2;
+  background: #0891b2;
+  color: #fff;
+}
+
+.icon-btn {
+  flex: 0 0 auto;
+}
+
+.grid {
+  display: grid;
+  flex: 1;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-content: start;
+  gap: 10px;
+  overflow: auto;
+  padding: 0 14px 14px;
+}
+
+body.side-panel .grid {
+  grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
+}
+
+.grid.empty {
+  display: grid;
+  place-items: center;
+  color: #64748b;
+  font-size: 13px;
+  text-align: center;
+}
+
+.card {
+  overflow: hidden;
+  border: 1px solid #d8e1ec;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.card.selected {
+  border-color: #0891b2;
+  box-shadow: 0 0 0 2px rgba(8, 145, 178, .16);
+}
+
+.thumb {
+  display: grid;
+  width: 100%;
+  aspect-ratio: 1.2;
+  place-items: center;
+  overflow: hidden;
+  background: #e2e8f0;
+}
+
+.thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px;
+  min-width: 0;
+}
+
+.meta span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: #334155;
+}
+
+footer {
+  justify-content: space-between;
+  border-top: 1px solid #d8e1ec;
+  background: #fff;
+}
+
+footer span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #64748b;
+  font-size: 12px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root,
+  body {
+    background: #101827;
+    color: #e5edf7;
+  }
+
+  .top,
+  footer,
+  .card,
+  button,
+  .settings input[type="text"] {
+    background: #172033;
+    color: #e5edf7;
+    border-color: #2d3b51;
+  }
+
+  .settings {
+    background: #111c2e;
+    border-color: #2d3b51;
+  }
+
+  .top p,
+  .settings label,
+  .summary,
+  footer span,
+  .meta span {
+    color: #a7b4c6;
+  }
+
+  .thumb {
+    background: #243145;
+  }
+}

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -1076,6 +1076,7 @@ const BatchProcessorNode = lazyCanvasNode(() => import('./nodes/BatchProcessorNo
 const BatchTaggerNode = lazyCanvasNode(() => import('./nodes/BatchTaggerNode'), 'BatchTaggerNode');
 const TopazImageUpscaleNode = lazyCanvasNode(() => import('./nodes/TopazImageUpscaleNode'), 'TopazImageUpscaleNode');
 const TopazVideoUpscaleNode = lazyCanvasNode(() => import('./nodes/TopazVideoUpscaleNode'), 'TopazVideoUpscaleNode');
+const TopazPhotoAINode = lazyCanvasNode(() => import('./nodes/TopazPhotoAINode'), 'TopazPhotoAINode');
 const IdeaNode = lazyCanvasNode(() => import('./nodes/IdeaNode'), 'IdeaNode');
 const BpNode = lazyCanvasNode(() => import('./nodes/BpNode'), 'BpNode');
 const RelayNode = lazyCanvasNode(() => import('./nodes/RelayNode'), 'RelayNode');
@@ -1180,6 +1181,7 @@ const SPECIFIC_NODES: Record<string, any> = {
   'batch-tagger': BatchTaggerNode,
   'topaz-image-upscale': TopazImageUpscaleNode,
   'topaz-video-upscale': TopazVideoUpscaleNode,
+  'topaz-photo-ai': TopazPhotoAINode,
   'panorama-3d': Panorama3DNode,
   // Input - 上传素材
   upload: UploadNode,
@@ -1474,6 +1476,28 @@ const INITIAL_DATA: Record<string, Record<string, any>> = {
     topazVideoShowAdvanced: false,
     videoUrl: '',
     videoUrls: [],
+    status: 'idle',
+    error: '',
+  },
+  'topaz-photo-ai': {
+    topazPhotoAiPath: '',
+    topazPhotoAiUpscale: false,
+    topazPhotoAiNoise: false,
+    topazPhotoAiSharpen: false,
+    topazPhotoAiLighting: false,
+    topazPhotoAiColor: false,
+    topazPhotoAiFormat: 'preserve',
+    topazPhotoAiQuality: 95,
+    topazPhotoAiCompression: 2,
+    topazPhotoAiBitDepth: 16,
+    topazPhotoAiTiffCompression: 'zip',
+    topazPhotoAiOverwrite: true,
+    topazPhotoAiShowAdvanced: false,
+    topazPhotoAiShowSettings: false,
+    topazPhotoAiExtraOverrides: '',
+    imageUrl: '',
+    imageUrls: [],
+    urls: [],
     status: 'idle',
     error: '',
   },
@@ -1926,7 +1950,7 @@ const EXECUTABLE_NODE_TYPES = new Set<string>([
   'loop', 'random-route', 'pick-from-set',
   // v1.4.8: 工具箱文本节点也可点击 RUN 直接外挂 OutputNode
   'cinematic', 'video-motion', 'multi-angle-visual', 'portrait-master', 'pose-master', 'aggregate-parser', 'batch-processor', 'batch-tagger',
-  'topaz-image-upscale', 'topaz-video-upscale',
+  'topaz-image-upscale', 'topaz-video-upscale', 'topaz-photo-ai',
   'remove-ai-watermark',
 ]);
 
@@ -1946,7 +1970,7 @@ const WEB_IMAGE_EXTENSION_MESSAGE_CONTRACT = {
   source: 't8-web-image-extension',
 } as const;
 
-type WebImageExtensionSendMode = 'prompt' | 'image' | 'both';
+type WebImageExtensionSendMode = 'prompt' | 'image' | 'both' | 'reference';
 
 interface WebImageExtensionPayload {
   messageId?: string;
@@ -1964,14 +1988,14 @@ type BasicMediaKind = Exclude<MediaKind, 'model3d'>;
 
 function normalizeWebImageSendMode(value: unknown): WebImageExtensionSendMode {
   const mode = String(value || '').trim();
-  return mode === 'prompt' || mode === 'image' || mode === 'both' ? mode : 'both';
+  return mode === 'prompt' || mode === 'image' || mode === 'both' || mode === 'reference' ? mode : 'both';
 }
 
 function cleanWebImageText(value: unknown, maxLen = 8000): string {
   return String(value || '').replace(/\s+/g, ' ').trim().slice(0, maxLen);
 }
 
-function webImagePayloadImages(payload: WebImageExtensionPayload): MediaItem[] {
+function webImagePayloadImages(payload: WebImageExtensionPayload, limit = 12): MediaItem[] {
   const raw = Array.isArray(payload.images) ? payload.images : payload.imageUrls;
   const seen = new Set<string>();
   const out: MediaItem[] = [];
@@ -1988,7 +2012,7 @@ function webImagePayloadImages(payload: WebImageExtensionPayload): MediaItem[] {
       size: typeof item === 'string' ? 0 : item.size || 0,
     });
   }
-  return out.slice(0, 12);
+  return out.slice(0, limit);
 }
 
 function buildWebImageSendNodeSpecs(payload: WebImageExtensionPayload): SendNodeSpec[] {
@@ -2014,7 +2038,21 @@ function buildWebImageSendNodeSpecs(payload: WebImageExtensionPayload): SendNode
       },
     });
   }
-  const imageItems = webImagePayloadImages(payload);
+  const imageItems = webImagePayloadImages(payload, mode === 'reference' ? 80 : 12);
+  if (mode === 'reference' && imageItems.length > 0) {
+    specs.push({
+      type: 'upload',
+      data: {
+        ...createUploadDataFromItems('image', imageItems),
+        sendSource: payload.source === 'web-asset-importer' ? 'web-asset-importer' : 'web-image-reverse',
+        source: payload.source === 'web-asset-importer' ? 'web-asset-importer' : 'web-image-reverse',
+        webImageReverseSourceImageUrl: sourceImageUrl,
+        webImageReversePageUrl: pageUrl,
+        webImageReversePageTitle: pageTitle,
+      },
+    });
+    return specs;
+  }
   if ((mode === 'image' || mode === 'both') && imageItems.length > 0) {
     specs.push({
       type: 'output',

--- a/tests/vibexBrowserBridge.test.ts
+++ b/tests/vibexBrowserBridge.test.ts
@@ -130,7 +130,7 @@ test('local browser bridge also queues web image reverse payloads for Electron c
 
 test('Chrome extension exposes a RunningHub VibeX bridge content script and backend fallback', () => {
   const manifest = JSON.parse(read('extension/manifest.json'));
-  assert.equal(manifest.version, '1.1.0');
+  assert.equal(manifest.version, '1.2.0');
   assert.ok(
     manifest.content_scripts.some((entry: any) =>
       entry.js?.includes('scripts/runninghub-bridge.js') &&

--- a/tests/webImageReverseToCanvas.test.ts
+++ b/tests/webImageReverseToCanvas.test.ts
@@ -245,8 +245,12 @@ test('web image reverse route pins the qwen-web VL model and stops unreadable vi
 test('web image Chrome extension exposes image context menu and canvas send modes', () => {
   const manifest = JSON.parse(readProjectFile('extension/manifest.json'));
   assert.equal(manifest.manifest_version, 3);
+  assert.equal(manifest.version, '1.2.0');
+  assert.equal(manifest.action.default_popup, 'popup.html');
+  assert.equal(manifest.side_panel.default_path, 'sidepanel.html');
   assert.ok(manifest.permissions.includes('contextMenus'));
   assert.ok(manifest.permissions.includes('scripting'));
+  assert.ok(manifest.permissions.includes('sidePanel'));
   assert.ok(manifest.host_permissions.includes('<all_urls>'));
   assert.equal(manifest.background.service_worker, 'scripts/background.js');
 
@@ -284,6 +288,19 @@ test('web image Chrome extension exposes image context menu and canvas send mode
 
   assert.match(background, /t8WebImage\.generateImage/);
   assert.match(background, /\/api\/proxy\/external\/image/);
+  assert.match(background, /t8WebImage\.importWebAssets/);
+  assert.match(background, /\/api\/web-assets\/import/);
+  assert.match(background, /mode:\s*['"]reference['"]/);
+
+  const importer = readProjectFile('extension/scripts/importer.js');
+  assert.match(importer, /collectPageImages/);
+  assert.match(importer, /captureVisibleTab/);
+  assert.match(importer, /fetchUrlsAsDataUrls/);
+  assert.match(importer, /t8WebImage\.importWebAssets/);
+  assert.match(readProjectFile('extension/popup.html'), /导入画布/);
+  assert.match(readProjectFile('extension/popup.html'), /scripts\/importer\.js/);
+  assert.match(readProjectFile('extension/sidepanel.html'), /导入画布/);
+  assert.match(readProjectFile('extension/sidepanel.html'), /scripts\/importer\.js/);
 });
 
 test('Canvas accepts web image extension payloads as prompt and output material nodes', () => {
@@ -299,6 +316,9 @@ test('Canvas accepts web image extension payloads as prompt and output material 
   assert.match(canvas, /const includePromptInOutput = mode === 'both' && !!prompt/);
   assert.match(canvas, /if \(mode === 'prompt' && prompt\)/);
   assert.match(canvas, /\.\.\.\(includePromptInOutput\s*\?\s*\{/);
+  assert.match(canvas, /mode === 'reference'/);
+  assert.match(canvas, /type:\s*'upload'/);
+  assert.match(canvas, /createUploadDataFromItems\('image', imageItems\)/);
 });
 
 test('Electron bridge web image payloads keep selected generation target behavior', () => {
@@ -310,4 +330,53 @@ test('Electron bridge web image payloads keep selected generation target behavio
   assert.match(canvas, /网页反推[\s\S]*提示词已写入选中的生成目标框/);
   assert.match(canvas, /message\?\.type === WEB_IMAGE_EXTENSION_MESSAGE_CONTRACT\.type/);
   assert.match(canvas, /importWebImagePayload\(message,\s*['"]网页反推['"]\)/);
+});
+
+test('web asset import route stores captured data URLs as local input files', async (t) => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 't8-web-assets-'));
+  t.after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const config = require('../backend/src/config.js');
+  const oldConfig = {
+    INPUT_DIR: config.INPUT_DIR,
+  };
+  t.after(() => Object.assign(config, oldConfig));
+  config.INPUT_DIR = path.join(tmpDir, 'input');
+
+  const webAssetsRouter = require('../backend/src/routes/webAssets.js');
+  const app = express();
+  app.use('/api/web-assets', webAssetsRouter);
+  const server = await listen(app);
+  t.after(() => server.close());
+
+  const base = `http://127.0.0.1:${server.address().port}`;
+  const result = await fetch(`${base}/api/web-assets/import`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      items: [
+        {
+          dataUrl: 'data:image/png;base64,iVBORw0KGgo=',
+          name: '网页参考图.png',
+          pageUrl: 'https://example.com/gallery',
+          pageTitle: 'Gallery',
+        },
+        {
+          url: 'http://127.0.0.1/private.png',
+          name: 'blocked.png',
+        },
+      ],
+    }),
+  }).then((res) => res.json());
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.count, 1);
+  assert.equal(result.data.failed, 1);
+  assert.match(result.data.items[0].url, /^\/files\/input\/web_/);
+  assert.equal(result.data.items[0].mime, 'image/png');
+  assert.equal(result.data.items[0].pageUrl, 'https://example.com/gallery');
+  assert.equal(fs.existsSync(path.join(config.INPUT_DIR, result.data.items[0].filename)), true);
+  assert.match(result.data.items[1].error, /不允许|不安全|仅支持|失败/);
 });


### PR DESCRIPTION
## Summary

This PR extends the existing web image reverse extension with an optional reference-image import flow.

It keeps the current prompt reverse / image generation behavior intact, and adds a popup + side panel flow that can scan the active page for images, capture the visible tab, import selected assets through the local T8 backend, and send them to the canvas as reference/upload image nodes.

## Changes

- Add `POST /api/web-assets/import` for importing selected web images or data URLs into the local input directory.
- Add SSRF-oriented guards for imported remote URLs, including private/local address blocking and manual redirect validation.
- Add extension popup and side panel UI for scanning page images, filtering small images, selecting assets, and importing them.
- Extend the extension background bridge to call the import endpoint and forward imported images to the canvas using a new `reference` mode.
- Extend canvas import handling so `reference` payloads create upload/reference image nodes instead of output material nodes.
- Allow the local VibeX bridge to accept the new `reference` mode.
- Add tests covering the new extension entry points, canvas handling, and backend import route.

## Validation

- `git diff --cached --check`
- `node --check backend/src/routes/webAssets.js`
- `node --check extension/scripts/background.js`
- `node --check extension/scripts/importer.js`
- `node --test tests/webImageReverseToCanvas.test.ts tests/vibexBrowserBridge.test.ts`