### PR TITLE
feat: add Volcengine asset-library plugin for v3.0

### DIFF
--- a/plugins/t8.volcengine-assets/backend/catalogStore.cjs
+++ b/plugins/t8.volcengine-assets/backend/catalogStore.cjs
@@ -1,0 +1,48 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function normalizeTags(value) {
+  const values = Array.isArray(value) ? value : String(value || '').split(/[,，\n]/);
+  return [...new Set(values.map((item) => String(item || '').trim()).filter(Boolean).map((item) => item.slice(0, 32)))].slice(0, 12);
+}
+
+function createCatalogStore(file) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  let state = { schema: 't8-volc-asset-catalog-v1', assets: {} };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (parsed && typeof parsed === 'object' && parsed.assets && typeof parsed.assets === 'object') state = parsed;
+  } catch (_) {}
+
+  function flush() {
+    const temporary = `${file}.${process.pid}.tmp`;
+    fs.writeFileSync(temporary, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+    fs.renameSync(temporary, file);
+  }
+
+  return {
+    tagsFor(assetId) {
+      const item = state.assets[String(assetId || '')];
+      return normalizeTags(item?.tags);
+    },
+    tagsForMany(assetIds) {
+      const out = {};
+      for (const assetId of Array.isArray(assetIds) ? assetIds : []) {
+        const id = String(assetId || '').trim();
+        if (id) out[id] = this.tagsFor(id);
+      }
+      return out;
+    },
+    setTags(assetId, tags) {
+      const id = String(assetId || '').trim();
+      if (!id) throw new Error('assetId 必填');
+      state.assets[id] = { tags: normalizeTags(tags), updatedAt: new Date().toISOString() };
+      flush();
+      return state.assets[id].tags;
+    },
+  };
+}
+
+module.exports = { createCatalogStore, normalizeTags };

--- a/plugins/t8.volcengine-assets/backend/index.cjs
+++ b/plugins/t8.volcengine-assets/backend/index.cjs
@@ -1,0 +1,193 @@
+'use strict';
+
+const path = require('node:path');
+const { resolvePersistentRoot, ensurePersistentLayout } = require('../storageRoot.cjs');
+const { createJobStore } = require('./jobStore.cjs');
+const { createCatalogStore, normalizeTags } = require('./catalogStore.cjs');
+
+const PLUGIN_ID = 't8.volcengine-assets';
+const PREFIX = '/api/plugins/volc-assets';
+
+function invokeCapability(ctx, name, input) {
+  if (typeof ctx?.capabilities?.invoke === 'function') return ctx.capabilities.invoke(name, input);
+  if (typeof ctx?.invokeCapability === 'function') return ctx.invokeCapability(name, input);
+  throw new Error('核心未提供 capability invoke');
+}
+
+function asyncRoute(handler) {
+  return (req, res, next) => Promise.resolve(handler(req, res, next)).catch((error) => {
+    const status = Number(error?.status) || 500;
+    const upstream = error?.payload?.ResponseMetadata?.Error;
+    const message = upstream?.Code === 'SignatureDoesNotMatch'
+      ? '火山 AK/SK 签名校验失败。请在 API 设置中重新粘贴同一对 IAM Access Key ID 和 Secret Access Key 后保存。'
+      : (error?.message || '火山资产请求失败');
+    res.status(status).json({ error: message, code: upstream?.Code || '' });
+  });
+}
+
+function requestBody(req) {
+  return req && req.body && typeof req.body === 'object' ? req.body : {};
+}
+
+function assetRef(job) {
+  const assetId = String(job.assetId || '').trim();
+  return assetId ? `Asset://${assetId}` : '';
+}
+
+function createRouter(ctx, express, store, catalog) {
+  const router = express.Router();
+  const call = (action, body, req) => invokeCapability(ctx, 'volcengine.assets.request', {
+    action,
+    profileId: requestBody(req).profileId || req?.query?.profileId || 'volcengine',
+    body,
+  });
+
+  router.get('/health', (_req, res) => res.json({ ok: true, pluginId: PLUGIN_ID, storageRoot: store.storageRoot }));
+  router.get('/groups', asyncRoute(async (req, res) => {
+    const projectName = String(req.query.projectName || '').trim();
+    res.json(await call('ListAssetGroups', { ProjectName: projectName, Filter: { GroupType: 'AIGC' } }, req));
+  }));
+  router.get('/assets', asyncRoute(async (req, res) => {
+    const groupId = String(req.query.groupId || '').trim();
+    const body = {
+      ProjectName: String(req.query.projectName || '').trim(),
+      Filter: {
+        GroupType: 'AIGC',
+        ...(groupId ? { GroupIds: [groupId] } : {}),
+      },
+      PageNumber: Number(req.query.pageNumber || 1),
+      PageSize: Math.min(100, Math.max(1, Number(req.query.pageSize || 20))),
+    };
+    res.json(await call('ListAssets', body, req));
+  }));
+  router.get('/assets/:assetId', asyncRoute(async (req, res) => {
+    res.json(await call('GetAsset', {
+      ProjectName: String(req.query.projectName || '').trim(),
+      Id: String(req.params.assetId || '').trim(),
+    }, req));
+  }));
+  router.get('/metadata', (req, res) => {
+    const assetIds = String(req.query.assetIds || '').split(',').map((value) => value.trim()).filter(Boolean).slice(0, 100);
+    res.json({ assets: catalog.tagsForMany(assetIds) });
+  });
+  router.put('/assets/:assetId/tags', (req, res) => {
+    const tags = catalog.setTags(req.params.assetId, normalizeTags(requestBody(req).tags));
+    res.json({ assetId: String(req.params.assetId || ''), tags });
+  });
+  router.post('/groups', asyncRoute(async (req, res) => {
+    const body = requestBody(req);
+    res.json(await call('CreateAssetGroup', {
+      ProjectName: String(body.projectName || '').trim(),
+      Name: String(body.name || '').trim(),
+      Description: String(body.description || '').trim() || undefined,
+    }, req));
+  }));
+  router.post('/assets/import', asyncRoute(async (req, res) => {
+    const body = requestBody(req);
+    const projectName = String(body.projectName || '').trim();
+    const url = String(body.url || '').trim();
+    const groupId = String(body.groupId || '').trim();
+    if (!groupId || !url) return res.status(400).json({ error: 'groupId 和 url 必填' });
+    const payload = {
+      ProjectName: projectName,
+      URL: url,
+      Name: String(body.name || '').trim() || undefined,
+      AssetType: String(body.kind || 'Image').trim(),
+      GroupId: groupId,
+    };
+    const response = await call('CreateAsset', payload, req);
+    const created = response?.Result || response?.result || response?.data || response;
+    const assetId = String(created?.Id || created?.AssetId || created?.assetId || '').trim();
+    const job = store.create({
+      projectName,
+      kind: payload.AssetType,
+      name: payload.Name || '',
+      sourceUrl: url,
+      assetId,
+      assetUri: assetId ? `Asset://${assetId}` : '',
+      status: assetId ? 'processing' : 'submitted',
+      providerResponse: { requestId: response?.ResponseMetadata?.RequestId || '' },
+    });
+    res.status(202).json(job);
+  }));
+  router.get('/jobs', (_req, res) => res.json({ jobs: store.list() }));
+  router.get('/jobs/:jobId', (req, res) => {
+    const job = store.get(req.params.jobId);
+    if (!job) return res.status(404).json({ error: '任务不存在' });
+    res.json(job);
+  });
+
+  return router;
+}
+
+function mountRouter(ctx, router) {
+  if (typeof ctx?.http?.registerRouter === 'function') return ctx.http.registerRouter(PREFIX, router);
+  if (typeof ctx?.registerRouter === 'function') return ctx.registerRouter(PREFIX, router);
+  if (ctx?.app?.use) return ctx.app.use(PREFIX, router);
+  throw new Error('核心未提供 registerRouter/app.use');
+}
+
+function startPoller(ctx, store, logger = console) {
+  let running = false;
+  const tick = async () => {
+    if (running) return;
+    running = true;
+    try {
+      for (const job of store.list()) {
+        if (!job.assetId || ['active', 'failed'].includes(job.status)) continue;
+        try {
+          const response = await invokeCapability(ctx, 'volcengine.assets.request', {
+            action: 'GetAsset',
+            profileId: job.profileId || 'volcengine',
+            body: { ProjectName: job.projectName, Id: job.assetId },
+          });
+          const asset = response?.Result?.Asset || response?.Result || response?.result || response?.data || {};
+          const upstreamStatus = String(asset?.Status || asset?.status || '').toLowerCase();
+          const nextStatus = upstreamStatus === 'active'
+            ? 'active'
+            : upstreamStatus === 'failed' ? 'failed' : 'processing';
+          store.put({
+            ...job,
+            status: nextStatus,
+            assetUri: assetRef({ assetId: job.assetId }),
+            previewUrl: '',
+            error: nextStatus === 'failed' ? String(asset?.Message || asset?.ErrorMessage || '火山资产处理失败') : '',
+            updatedAt: new Date().toISOString(),
+          });
+        } catch (error) {
+          logger.warn?.('[t8.volcengine-assets] poll failed', job.id, error?.message || error);
+        }
+      }
+    } finally {
+      running = false;
+    }
+  };
+  const timer = setInterval(() => { void tick(); }, 5000);
+  timer.unref?.();
+  void tick();
+  return () => clearInterval(timer);
+}
+
+function register(ctx = {}) {
+  const express = ctx.express || require('express');
+  const root = resolvePersistentRoot({ root: ctx.paths?.pluginDataRoot, executablePath: ctx.paths?.executablePath });
+  const layout = ensurePersistentLayout(root);
+  const store = createJobStore(path.join(layout.dataRoot, 'jobs.json'));
+  const catalog = createCatalogStore(path.join(layout.dataRoot, 'catalog.json'));
+  store.storageRoot = layout.root;
+  const router = createRouter(ctx, express, store, catalog);
+  const unmount = mountRouter(ctx, router);
+  const stopPoller = startPoller(ctx, store, ctx.logger || console);
+  ctx.logger?.info?.(`[${PLUGIN_ID}] loaded; persistent root=${layout.root}`);
+  return {
+    pluginId: PLUGIN_ID,
+    nodeType: 'volc-asset',
+    layout,
+    dispose: () => {
+      stopPoller();
+      if (typeof unmount === 'function') unmount();
+    },
+  };
+}
+
+module.exports = { id: PLUGIN_ID, version: '0.1.0', register };

--- a/plugins/t8.volcengine-assets/backend/jobStore.cjs
+++ b/plugins/t8.volcengine-assets/backend/jobStore.cjs
@@ -1,0 +1,42 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function createJobStore(file) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  let jobs = {};
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (parsed && typeof parsed === 'object' && parsed.jobs && typeof parsed.jobs === 'object') jobs = parsed.jobs;
+  } catch (_) {}
+
+  function flush() {
+    const temp = `${file}.${process.pid}.${crypto.randomUUID()}.tmp`;
+    fs.writeFileSync(temp, `${JSON.stringify({ schema: 't8-volc-asset-jobs-v1', jobs }, null, 2)}\n`, 'utf8');
+    fs.renameSync(temp, file);
+  }
+
+  return {
+    list() { return Object.values(clone(jobs)); },
+    get(id) { return jobs[id] ? clone(jobs[id]) : null; },
+    put(job) { jobs[job.id] = clone(job); flush(); return clone(job); },
+    create(input) {
+      const job = {
+        id: `volcjob-${Date.now().toString(36)}-${crypto.randomBytes(4).toString('hex')}`,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        status: 'submitted',
+        ...input,
+      };
+      return this.put(job);
+    },
+  };
+}
+
+module.exports = { createJobStore };

--- a/plugins/t8.volcengine-assets/core/README.md
+++ b/plugins/t8.volcengine-assets/core/README.md
@@ -1,0 +1,24 @@
+# 3.0 核心接入点
+
+当前官方 3.0 客户端没有运行时插件宿主，因此本目录中的能力代理需要由核心构建接入一次。接入后，插件本身和插件数据均可放在安装目录旁的 E 盘目录。
+
+## 必须接入的能力
+
+1. 在 Electron 启动早期创建 capability registry，并调用 `registerVolcengineAssetsCapability`。
+2. 在 Electron IPC 中调用 `installPluginDirectory`，安装到 `layout.pluginRoot`；安装完成后重启加载，首版不热更新。
+3. 在后端路由注册阶段使用 `loadInstalledPlugins`，将 `ctx.capabilities.invoke` 和 `ctx.registerRouter` 传入。
+4. 在前端节点注册阶段合并插件的 `nodeDefinition`。
+5. 在画布节点 Schema 合并 `schema/volc-asset.node.json`。
+6. 对 Provider 媒体解析增加仅限 Volcengine 的 `asset://asset-...` 受控透传。
+
+## 凭据边界
+
+`volcengineAssetsCapability.cjs` 只从核心设置加载 AK/SK，插件请求只能调用白名单 Action。AK/SK 不会进入插件前端、节点数据或响应体。
+
+## E 盘目录
+
+`storageRoot.cjs` 会把已安装客户端 `E:\\T8整合包\\T8-PenguinCanvas\\T8-PenguinCanvas.exe` 解析为：
+
+`E:\\T8整合包\\T8-PenguinCanvas-Data`
+
+可通过核心传入 `ctx.paths.pluginDataRoot` 或环境变量 `T8_PLUGIN_DATA_ROOT` 覆盖，但必须是绝对路径。

--- a/plugins/t8.volcengine-assets/core/pluginHost.cjs
+++ b/plugins/t8.volcengine-assets/core/pluginHost.cjs
@@ -1,0 +1,93 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const API_VERSION = 1;
+const PLUGIN_ID = /^[a-z][a-z0-9._-]{2,63}$/;
+
+function inside(root, target) {
+  const base = `${path.resolve(root)}${path.sep}`;
+  return path.resolve(target).startsWith(base);
+}
+
+function readManifest(pluginDir) {
+  const manifestFile = path.join(pluginDir, 'plugin.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
+  if (!PLUGIN_ID.test(String(manifest.id || ''))) throw new Error('插件 id 不符合规范');
+  if (Number(manifest.apiVersion) !== API_VERSION) throw new Error(`不支持的插件 API 版本: ${manifest.apiVersion}`);
+  if (!manifest.entry || typeof manifest.entry !== 'object') throw new Error('插件缺少 entry');
+  for (const key of ['backend', 'frontend']) {
+    const entry = String(manifest.entry[key] || '').trim();
+    if (!entry || path.isAbsolute(entry) || entry.includes('..') || !inside(pluginDir, path.join(pluginDir, entry))) {
+      throw new Error(`插件 entry 非法: ${key}`);
+    }
+  }
+  return manifest;
+}
+
+function installPluginDirectory(sourceDir, pluginRoot) {
+  const source = path.resolve(sourceDir);
+  const root = path.resolve(pluginRoot);
+  const manifest = readManifest(source);
+  fs.mkdirSync(root, { recursive: true });
+  const target = path.join(root, manifest.id);
+  if (!inside(root, target)) throw new Error('插件目标目录越界');
+  if (fs.existsSync(target)) throw new Error(`插件已安装: ${manifest.id}`);
+  const staging = path.join(root, `.install-${manifest.id}-${crypto.randomUUID()}`);
+  try {
+    fs.cpSync(source, staging, { recursive: true, errorOnExist: true });
+    readManifest(staging);
+    fs.renameSync(staging, target);
+  } catch (error) {
+    fs.rmSync(staging, { recursive: true, force: true });
+    throw error;
+  }
+  return { manifest, directory: target };
+}
+
+function listInstalledPlugins(pluginRoot) {
+  const root = path.resolve(pluginRoot);
+  if (!fs.existsSync(root)) return [];
+  return fs.readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.'))
+    .map((entry) => {
+      const directory = path.join(root, entry.name);
+      try { return { directory, manifest: readManifest(directory) }; } catch (error) {
+        return { directory, error: error.message };
+      }
+    });
+}
+
+function loadInstalledPlugins({ pluginRoot, hostContext = {}, logger = console } = {}) {
+  const loaded = [];
+  for (const item of listInstalledPlugins(pluginRoot)) {
+    if (item.error) {
+      logger.warn?.('[t8-plugin-host] skipped invalid plugin', item.directory, item.error);
+      continue;
+    }
+    const manifest = item.manifest;
+    const context = {
+      ...hostContext,
+      plugin: manifest,
+      paths: { ...(hostContext.paths || {}), pluginDirectory: item.directory },
+    };
+    let backend = null;
+    if (manifest.entry.backend) {
+      backend = require(path.join(item.directory, manifest.entry.backend));
+      if (typeof backend?.register !== 'function') throw new Error(`插件后端缺少 register: ${manifest.id}`);
+      backend.register(context);
+    }
+    loaded.push({ manifest, directory: item.directory, backend });
+  }
+  return loaded;
+}
+
+module.exports = {
+  API_VERSION,
+  readManifest,
+  installPluginDirectory,
+  listInstalledPlugins,
+  loadInstalledPlugins,
+};

--- a/plugins/t8.volcengine-assets/core/pluginHost.test.cjs
+++ b/plugins/t8.volcengine-assets/core/pluginHost.test.cjs
@@ -1,0 +1,28 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { installPluginDirectory, listInstalledPlugins, readManifest } = require('./pluginHost.cjs');
+
+const pluginDir = path.resolve(__dirname, '..');
+
+test('plugin manifest is valid for the 3.0 host contract', () => {
+  const manifest = readManifest(pluginDir);
+  assert.equal(manifest.id, 't8.volcengine-assets');
+  assert.equal(manifest.minHostVersion, '3.0.0');
+});
+
+test('installer rejects duplicate and path traversal manifests', () => {
+  const source = fs.mkdtempSync(path.join(os.tmpdir(), 't8-plugin-source-'));
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 't8-plugin-host-'));
+  fs.cpSync(pluginDir, source, { recursive: true });
+  const first = installPluginDirectory(source, root);
+  assert.equal(first.manifest.id, 't8.volcengine-assets');
+  assert.throws(() => installPluginDirectory(source, root), /插件已安装/);
+  assert.equal(listInstalledPlugins(root).length, 1);
+  fs.rmSync(source, { recursive: true, force: true });
+  fs.rmSync(root, { recursive: true, force: true });
+});

--- a/plugins/t8.volcengine-assets/core/volcengineAssetsCapability.cjs
+++ b/plugins/t8.volcengine-assets/core/volcengineAssetsCapability.cjs
@@ -1,0 +1,81 @@
+'use strict';
+
+const { signRequest } = require('./volcengineSigner.cjs');
+
+const SERVICE = 'ark';
+const VERSION = '2024-01-01';
+const REGION = 'cn-beijing';
+const HOST = 'open.volcengineapi.com';
+const ALLOWED_ACTIONS = new Set([
+  'CreateAsset',
+  'GetAsset',
+  'ListAssets',
+  'CreateAssetGroup',
+  'ListAssetGroups',
+  'GetAssetGroup',
+]);
+
+function findVolcengineConfig(settings, profileId = 'volcengine') {
+  const providers = Array.isArray(settings?.advancedProviders) ? settings.advancedProviders : [];
+  const provider = providers.find((item) => String(item?.id || '') === String(profileId))
+    || providers.find((item) => item?.protocol === 'volcengine');
+  const config = provider?.volcengineConfig || {};
+  return {
+    project: String(config.project || '').trim(),
+    region: String(config.region || REGION).trim() || REGION,
+    accessKeyId: String(config.accessKeyId || '').trim(),
+    secretAccessKey: String(config.secretAccessKey || '').trim(),
+  };
+}
+
+function validateBody(action, body) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) throw new Error('火山资产请求体必须是对象');
+  if (action === 'CreateAsset' && !String(body.GroupId || '').trim()) throw new Error('CreateAsset 缺少 GroupId');
+  if (action === 'CreateAsset' && !String(body.URL || '').trim()) throw new Error('CreateAsset 缺少公开可访问的 URL');
+}
+
+function registerVolcengineAssetsCapability({ capabilities, loadSettings, logger = console, fetchImpl = globalThis.fetch }) {
+  if (!capabilities || typeof capabilities.register !== 'function') throw new Error('核心缺少 capability registry');
+  if (typeof loadSettings !== 'function') throw new Error('核心缺少 settings loader');
+  if (typeof fetchImpl !== 'function') throw new Error('运行时缺少 fetch');
+
+  capabilities.register('volcengine.assets.request', async (input = {}) => {
+    const action = String(input.action || '').trim();
+    if (!ALLOWED_ACTIONS.has(action)) throw new Error(`火山资产 Action 不在白名单: ${action}`);
+    const cfg = findVolcengineConfig(loadSettings(), input.profileId);
+    if (!cfg.accessKeyId || !cfg.secretAccessKey) throw new Error('请先在贞贞画布火山引擎设置中填写 AK/SK');
+    const body = input.body && typeof input.body === 'object' ? input.body : {};
+    validateBody(action, body);
+    const rawBody = JSON.stringify(body);
+    const uri = `/open/${action}`;
+    const query = { Action: action, Version: VERSION };
+    const headers = signRequest({
+      accessKeyId: cfg.accessKeyId,
+      secretAccessKey: cfg.secretAccessKey,
+      region: cfg.region,
+      service: SERVICE,
+      host: HOST,
+      uri,
+      query,
+      body: rawBody,
+    });
+    const response = await fetchImpl(`https://${HOST}${uri}?Action=${encodeURIComponent(action)}&Version=${VERSION}`, {
+      method: 'POST',
+      headers,
+      body: rawBody,
+    });
+    const text = await response.text();
+    let payload;
+    try { payload = text ? JSON.parse(text) : {}; } catch (_) { payload = { raw: text }; }
+    if (!response.ok) {
+      logger.warn?.('[volcengine-assets] request failed', response.status, action);
+      const error = new Error(payload?.ResponseMetadata?.Error?.Message || `火山资产请求失败 (${response.status})`);
+      error.status = response.status;
+      error.payload = payload;
+      throw error;
+    }
+    return payload;
+  });
+}
+
+module.exports = { registerVolcengineAssetsCapability, findVolcengineConfig, ALLOWED_ACTIONS };

--- a/plugins/t8.volcengine-assets/core/volcengineSigner.cjs
+++ b/plugins/t8.volcengine-assets/core/volcengineSigner.cjs
@@ -1,0 +1,74 @@
+'use strict';
+
+const crypto = require('node:crypto');
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function hmac(key, value, encoding) {
+  return crypto.createHmac('sha256', key).update(value).digest(encoding);
+}
+
+function encodeQuery(value) {
+  return encodeURIComponent(String(value)).replace(/[!'()*]/g, (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`);
+}
+
+function canonicalQuery(query = {}) {
+  return Object.keys(query)
+    .filter((key) => query[key] !== undefined && query[key] !== null)
+    .sort()
+    .map((key) => `${encodeQuery(key)}=${encodeQuery(query[key])}`)
+    .join('&');
+}
+
+function signRequest(options) {
+  const {
+    accessKeyId,
+    secretAccessKey,
+    region = 'cn-beijing',
+    service = 'ark',
+    method = 'POST',
+    host = 'open.volcengineapi.com',
+    uri = '/',
+    query = {},
+    body = '',
+    now = new Date(),
+  } = options;
+  if (!accessKeyId || !secretAccessKey) throw new Error('火山资产 API 缺少 AK/SK');
+
+  const xDate = now.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+  const shortDate = xDate.slice(0, 8);
+  const payloadHash = sha256(body);
+  const contentType = 'application/json; charset=UTF-8';
+  const canonicalHeaders = `host:${host}\nx-content-sha256:${payloadHash}\nx-date:${xDate}\n`;
+  const signedHeaders = 'host;x-content-sha256;x-date';
+  const canonicalRequest = [
+    method.toUpperCase(),
+    uri,
+    canonicalQuery(query),
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join('\n');
+  const credentialScope = `${shortDate}/${region}/${service}/request`;
+  const stringToSign = [
+    'HMAC-SHA256',
+    xDate,
+    credentialScope,
+    sha256(canonicalRequest),
+  ].join('\n');
+  const signingKey = hmac(hmac(hmac(hmac(secretAccessKey, shortDate), region), service), 'request');
+  const signature = hmac(signingKey, stringToSign, 'hex');
+  const authorization = `HMAC-SHA256 Credential=${accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+  return {
+    'Content-Type': contentType,
+    Host: host,
+    'X-Content-Sha256': payloadHash,
+    'X-Date': xDate,
+    Authorization: authorization,
+  };
+}
+
+module.exports = { signRequest };

--- a/plugins/t8.volcengine-assets/frontend/index.tsx
+++ b/plugins/t8.volcengine-assets/frontend/index.tsx
@@ -1,0 +1,38 @@
+import { VolcAssetNode } from '../../../src/components/nodes/VolcAssetNode';
+
+// Keep the plugin entry point on the same implementation as the built-in node.
+// This prevents the plugin loader from replacing the folder-aware multi-select
+// UI with the legacy single-select dropdown when both registrations are active.
+export { VolcAssetNode };
+
+export const nodeDefinition = {
+  type: 'volc-asset',
+  label: '火山素材库',
+  category: 'input',
+  defaultData: {
+    profileId: 'volcengine',
+    projectName: '',
+    groupId: '',
+    groupIds: [],
+    assetId: '',
+    assetUri: '',
+    selectedAssets: [],
+    materialSetKind: '',
+    materialSetItems: [],
+    kind: 'image',
+    status: 'Processing',
+    tags: [],
+    error: '',
+    size: { w: 680, h: 510 },
+    volcAssetLayoutVersion: 3,
+  },
+  component: VolcAssetNode,
+};
+
+export function register(ctx: any) {
+  if (typeof ctx?.nodes?.register !== 'function') throw new Error('核心未提供 nodes.register');
+  ctx.nodes.register(nodeDefinition);
+  return () => ctx.nodes.unregister?.('volc-asset');
+}
+
+export default { id: 't8.volcengine-assets', version: '0.3.0', register, nodeDefinition };

--- a/plugins/t8.volcengine-assets/plugin.json
+++ b/plugins/t8.volcengine-assets/plugin.json
@@ -1,0 +1,35 @@
+{
+  "id": "t8.volcengine-assets",
+  "name": "火山资产库",
+  "version": "0.3.0",
+  "apiVersion": 1,
+  "host": "t8-penguin-canvas",
+  "minHostVersion": "3.0.0",
+  "trust": "core-reviewed",
+  "entry": {
+    "backend": "backend/index.cjs",
+    "frontend": "frontend/index.tsx"
+  },
+  "storage": {
+    "rootPolicy": "sibling",
+    "directoryName": "T8-PenguinCanvas-Data",
+    "subdirectories": ["plugins", "plugin-data", "staging", "cache"]
+  },
+  "permissions": [
+    "canvas.node.register",
+    "canvas.node.execute",
+    "volcengine.assets.request",
+    "storage.plugin"
+  ],
+  "nodes": [
+    {
+      "type": "volc-asset",
+      "label": "火山资产",
+      "category": "input",
+      "ports": {
+        "inputs": [],
+        "outputs": ["image", "video", "audio"]
+      }
+    }
+  ]
+}

--- a/plugins/t8.volcengine-assets/schema/volc-asset.node.json
+++ b/plugins/t8.volcengine-assets/schema/volc-asset.node.json
@@ -1,0 +1,46 @@
+{
+  "type": "volc-asset",
+  "label": "火山素材库",
+  "category": "input",
+  "description": "在画布中直接浏览、管理并引用火山方舟私域素材",
+  "icon": "LibraryBig",
+  "color": "orange",
+  "ports": {
+    "inputs": [],
+    "outputs": ["image", "video", "audio"]
+  },
+  "executable": true,
+  "generatable": false,
+  "generation": {
+    "allowedDataFields": {
+      "profileId": { "type": "string", "maxLength": 128 },
+      "projectName": { "type": "string", "maxLength": 128 },
+      "groupId": { "type": "string", "maxLength": 256 },
+      "assetId": { "type": "string", "maxLength": 256 },
+      "assetUri": { "type": "string", "pattern": "^asset://asset-[A-Za-z0-9-]+$" },
+      "selectedAssets": { "type": "array", "maxItems": 15, "items": { "type": "object" } },
+      "materialSetKind": { "type": "string", "enum": ["", "image", "video", "audio"] },
+      "materialSetItems": { "type": "array", "maxItems": 15, "items": { "type": "object" } },
+      "kind": { "type": "string", "enum": ["image", "video", "audio"] },
+      "status": { "type": "string", "enum": ["Processing", "Active", "Failed"] },
+      "tags": { "type": "array", "items": { "type": "string", "maxLength": 32 }, "maxItems": 12 },
+      "volcAssetLayoutVersion": { "type": "number", "minimum": 1, "maximum": 3 }
+    },
+    "defaults": {
+      "profileId": "volcengine",
+      "projectName": "",
+      "groupId": "",
+      "assetId": "",
+      "assetUri": "",
+      "kind": "image",
+      "status": "Processing",
+      "tags": [],
+      "error": "",
+      "selectedAssets": [],
+      "materialSetKind": "",
+      "materialSetItems": [],
+      "size": { "w": 680, "h": 510 },
+      "volcAssetLayoutVersion": 3
+    }
+  }
+}

--- a/plugins/t8.volcengine-assets/storageRoot.cjs
+++ b/plugins/t8.volcengine-assets/storageRoot.cjs
@@ -1,0 +1,45 @@
+'use strict';
+
+const path = require('node:path');
+const fs = require('node:fs');
+
+function isAbsolute(value) {
+  return typeof value === 'string' && path.isAbsolute(value);
+}
+
+/**
+ * Resolve persistent plugin data outside the install directory.
+ * For the user's install this becomes E:\\T8整合包\\T8-PenguinCanvas-Data.
+ */
+function resolvePersistentRoot(options = {}) {
+  const explicit = String(options.root || process.env.T8_PLUGIN_DATA_ROOT || '').trim();
+  if (explicit) {
+    if (!isAbsolute(explicit)) throw new Error('T8_PLUGIN_DATA_ROOT 必须是绝对路径');
+    return path.resolve(explicit);
+  }
+
+  const executable = String(options.executablePath || process.execPath || '').trim();
+  if (isAbsolute(executable)) {
+    const installDir = path.dirname(executable);
+    return path.resolve(installDir, '..', 'T8-PenguinCanvas-Data');
+  }
+
+  return path.resolve(process.cwd(), 'T8-PenguinCanvas-Data');
+}
+
+function ensurePersistentLayout(root) {
+  const directories = ['plugins', 'plugin-data', 'staging', 'cache'];
+  fs.mkdirSync(root, { recursive: true });
+  for (const directory of directories) fs.mkdirSync(path.join(root, directory), { recursive: true });
+  const layout = {
+    root,
+    pluginRoot: path.join(root, 'plugins'),
+    dataRoot: path.join(root, 'plugin-data', 'volcengine-assets'),
+    stagingRoot: path.join(root, 'staging', 'volcengine-assets'),
+    cacheRoot: path.join(root, 'cache', 'volcengine-assets'),
+  };
+  for (const directory of [layout.dataRoot, layout.stagingRoot, layout.cacheRoot]) fs.mkdirSync(directory, { recursive: true });
+  return Object.freeze(layout);
+}
+
+module.exports = { resolvePersistentRoot, ensurePersistentLayout };


### PR DESCRIPTION
## Summary
Adds the Volcengine asset-library plugin as a plugin-only change for T8 Penguin Canvas.

- Registers the 火山资产 node and image/video/audio output ports.
- Adds Volcengine asset catalog, job polling, signing, storage, and capability adapters.
- Supports mixed asset selection with a maximum of 15 items and stable asset://asset-... references.
- Keeps AK/SK in the host settings boundary; no credentials or user data are included.

## Integration notes
- This branch is based on upstream v3.0.0 (92ca7a4ee8748f46fdfb1b624bff26acda6b18dd).
- The host needs to register the plugin loader/capability hooks described in plugins/t8.volcengine-assets/core/README.md.
- The PR adds only plugins/t8.volcengine-assets/**; no core canvas files are changed.

## Validation
- node plugins/t8.volcengine-assets/core/pluginHost.test.cjs (2 tests passing)
